### PR TITLE
Notebook testing in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.pythonLocation }}-pip-
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests
+        run: >
+          pytest
+          --nbval-lax .
+          --junitxml=test_report.xml
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: ./test_report.xml
+          check_name: Test results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+numpy
+pandas
+seaborn
+scikit-learn
+prophet
+pytest
+pytest-sugar
+nbval


### PR DESCRIPTION
This PR adds lax testing of notebooks using _pytest_ and _nbval_ in CI.
That is, the `.ipynb` files are tested to run w/o errors (output not checked).

Currently, the notebooks themselves don't seem to run due to missing data.

* `requirements.txt` added as well
* uses caching for dependencies